### PR TITLE
Resolve Labeling Conflict: Assign Unique Colors to a Tooth and Gingiva Labels

### DIFF
--- a/gen_utils.py
+++ b/gen_utils.py
@@ -69,10 +69,10 @@ def get_colored_mesh(mesh, label_arr):
     ])/255
     palte[9:] *= 0.4
     label_arr = label_arr.copy()
-    label_arr %= palte.shape[0]
     label_colors = np.zeros((label_arr.shape[0], 3))
-    for idx, palte_color in enumerate(palte):
-        label_colors[label_arr==idx] = palte[idx]
+    unique_labels = np.unique(label_arr)
+    for idx, label in enumerate(unique_labels):
+        label_colors[label_arr == label] = palte[idx]
     mesh.vertex_colors = o3d.utility.Vector3dVector(label_colors)
     return mesh
 


### PR DESCRIPTION
I identified a potential issue in the labeling system where taking the modulo operation (%17) with each array element resulted in a lack of distinction between gingiva and Lower Left 4 (LL4). Specifically, when the FDI system assigned 34 to LL4, taking 34%17 resulted in 0, causing overlap with the gingiva label. It'll cause an exact issue with UR7. To rectify this, I have made adjustments to ensure a distinction between these elements in our predictions. This improvement aims to enhance the accuracy and specificity of our labeling system.

**Issue:**
![image](https://github.com/limhoyeon/ToothGroupNetwork/assets/8472339/89f5295b-e6cc-40b4-bf9a-abbe66165738)

**Fixed:**
![image](https://github-production-user-asset-6210df.s3.amazonaws.com/8472339/284247357-8a8703a7-0e12-4dd5-9e76-0a6f3fd00f9f.png)

